### PR TITLE
Switch to vimhelp.appspot.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vim-flavor
 Gemfile.lock
 VimFlavor.lock
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'vim-flavor', '~> 1.1'
+gem 'vim-flavor', '1.1'
+gem 'rake'

--- a/autoload/help/docopen.vim
+++ b/autoload/help/docopen.vim
@@ -21,6 +21,10 @@ function! help#docopen#GetHelptag()
   endif
 endfunction
 
+function! help#docopen#UrlEncode(input)
+  return substitute(a:input,'[^A-Za-z0-9_.~-]','\="%".printf("%02X",char2nr(submatch(0)))','g')
+endfunction
+
 function! help#docopen#RawUrl(filename, ...)
   if a:0 ==# 1 && a:1 !=# ''
     return 'http://vimhelp.appspot.com/' . a:filename . '.txt.html#' . a:1

--- a/autoload/help/docopen.vim
+++ b/autoload/help/docopen.vim
@@ -14,7 +14,8 @@ function! help#docopen#GetHelptag()
   let word = expand('<cWORD>')
   let stripped = substitute(word, '\v^\*([^*]*)\*$', '\1', 'g')
   if word !=# stripped
-    return stripped
+    let escaped = substitute(stripped,'[^A-Za-z0-9_.~-]','\="%".printf("%02X",char2nr(submatch(0)))','g')
+    return escaped
   else
     return ''
   endif

--- a/autoload/help/docopen.vim
+++ b/autoload/help/docopen.vim
@@ -22,9 +22,9 @@ endfunction
 
 function! help#docopen#RawUrl(filename, ...)
   if a:0 ==# 1 && a:1 !=# ''
-    return 'http://vimdoc.sourceforge.net/htmldoc/' . a:filename . '.html#' . a:1
+    return 'http://vimhelp.appspot.com/' . a:filename . '.txt.html#' . a:1
   else
-    return 'http://vimdoc.sourceforge.net/htmldoc/' . a:filename . '.html'
+    return 'http://vimhelp.appspot.com/' . a:filename . '.txt.html'
   endif
 endfunction
 

--- a/autoload/help/docopen.vim
+++ b/autoload/help/docopen.vim
@@ -14,8 +14,7 @@ function! help#docopen#GetHelptag()
   let word = expand('<cWORD>')
   let stripped = substitute(word, '\v^\*([^*]*)\*$', '\1', 'g')
   if word !=# stripped
-    let escaped = substitute(stripped,'[^A-Za-z0-9_.~-]','\="%".printf("%02X",char2nr(submatch(0)))','g')
-    return escaped
+    return stripped
   else
     return ''
   endif
@@ -27,7 +26,7 @@ endfunction
 
 function! help#docopen#RawUrl(filename, ...)
   if a:0 ==# 1 && a:1 !=# ''
-    return 'http://vimhelp.appspot.com/' . a:filename . '.txt.html#' . a:1
+    return 'http://vimhelp.appspot.com/' . a:filename . '.txt.html#' . help#docopen#UrlEncode(a:1)
   else
     return 'http://vimhelp.appspot.com/' . a:filename . '.txt.html'
   endif

--- a/t/docopen-test.vim
+++ b/t/docopen-test.vim
@@ -44,6 +44,16 @@ describe 'help#GetHelptag'
 
 end
 
+describe 'help#UrlEncode'
+
+  it 'escapes non-safe characters'
+    Expect help#docopen#UrlEncode("'") ==# "%27"
+    Expect help#docopen#UrlEncode('{offset}') ==# '%7Boffset%7D'
+    Expect help#docopen#UrlEncode('/\&') ==# '%2F%5C%26'
+  end
+
+end
+
 describe 'help#GenarateUrl'
 
   it 'generates an URL from specified filename and helptag'

--- a/t/docopen-test.vim
+++ b/t/docopen-test.vim
@@ -23,11 +23,11 @@ describe 'help#GetHelptag'
     help search-offset
     Expect help#docopen#GetHelptag() ==# 'search-offset'
     help {offset}
-    Expect help#docopen#GetHelptag() ==# '%7Boffset%7D'
+    Expect help#docopen#GetHelptag() ==# '{offset}'
     help /\&
-    Expect help#docopen#GetHelptag() ==# '%2F%5C%26'
+    Expect help#docopen#GetHelptag() ==# '/\&'
     help '
-    Expect help#docopen#GetHelptag() ==# "%27"
+    Expect help#docopen#GetHelptag() ==# "'"
     help "
     Expect help#docopen#GetHelptag() ==# "quote"
   end
@@ -78,6 +78,11 @@ describe 'help#GenarateUrl'
   it 'generates an URL from contextual filename and helptag'
     help j
     Expect help#docopen#RawUrl(help#docopen#GetFilename(), help#docopen#GetHelptag()) ==# 'http://vimhelp.appspot.com/motion.txt.html#j'
+  end
+
+  it 'generates an URL from contextual filename and escaped helptag'
+    help {offset}
+    Expect help#docopen#RawUrl(help#docopen#GetFilename(), help#docopen#GetHelptag()) ==# 'http://vimhelp.appspot.com/pattern.txt.html#%7Boffset%7D'
   end
 
 end

--- a/t/docopen-test.vim
+++ b/t/docopen-test.vim
@@ -47,27 +47,27 @@ end
 describe 'help#GenarateUrl'
 
   it 'generates an URL from specified filename and helptag'
-    Expect help#docopen#RawUrl('foo', 'bar') ==# 'http://vimdoc.sourceforge.net/htmldoc/foo.html#bar'
+    Expect help#docopen#RawUrl('foo', 'bar') ==# 'http://vimhelp.appspot.com/foo.txt.html#bar'
   end
 
   it 'generates an URL from specified filename given a blank helptag'
-    Expect help#docopen#RawUrl('foo', '') ==# 'http://vimdoc.sourceforge.net/htmldoc/foo.html'
+    Expect help#docopen#RawUrl('foo', '') ==# 'http://vimhelp.appspot.com/foo.txt.html'
   end
 
   it 'generates an URL from specified filename'
-    Expect help#docopen#RawUrl('foo') ==# 'http://vimdoc.sourceforge.net/htmldoc/foo.html'
+    Expect help#docopen#RawUrl('foo') ==# 'http://vimhelp.appspot.com/foo.txt.html'
   end
 
   it 'generates an URL from contextual filename'
     help
     " Jump to the first blank line (so there's no helptag beneath cursor)
     normal! }
-    Expect help#docopen#RawUrl(help#docopen#GetFilename(), help#docopen#GetHelptag()) ==# 'http://vimdoc.sourceforge.net/htmldoc/help.html'
+    Expect help#docopen#RawUrl(help#docopen#GetFilename(), help#docopen#GetHelptag()) ==# 'http://vimhelp.appspot.com/help.txt.html'
   end
 
   it 'generates an URL from contextual filename and helptag'
     help j
-    Expect help#docopen#RawUrl(help#docopen#GetFilename(), help#docopen#GetHelptag()) ==# 'http://vimdoc.sourceforge.net/htmldoc/motion.html#j'
+    Expect help#docopen#RawUrl(help#docopen#GetFilename(), help#docopen#GetHelptag()) ==# 'http://vimhelp.appspot.com/motion.txt.html#j'
   end
 
 end
@@ -82,12 +82,12 @@ describe 'ygd'
 
   it 'sets the default register to a help URL'
     normal ygd
-    Expect @@ ==# 'http://vimdoc.sourceforge.net/htmldoc/motion.html#j'
+    Expect @@ ==# 'http://vimhelp.appspot.com/motion.txt.html#j'
   end
 
   it 'sets the specified register to a help URL'
     normal "aygd
-    Expect @a ==# 'http://vimdoc.sourceforge.net/htmldoc/motion.html#j'
+    Expect @a ==# 'http://vimhelp.appspot.com/motion.txt.html#j'
   end
 
 end

--- a/t/docopen-test.vim
+++ b/t/docopen-test.vim
@@ -23,11 +23,11 @@ describe 'help#GetHelptag'
     help search-offset
     Expect help#docopen#GetHelptag() ==# 'search-offset'
     help {offset}
-    Expect help#docopen#GetHelptag() ==# '{offset}'
+    Expect help#docopen#GetHelptag() ==# '%7Boffset%7D'
     help /\&
-    Expect help#docopen#GetHelptag() ==# '/\&'
+    Expect help#docopen#GetHelptag() ==# '%2F%5C%26'
     help '
-    Expect help#docopen#GetHelptag() ==# "'"
+    Expect help#docopen#GetHelptag() ==# "%27"
     help "
     Expect help#docopen#GetHelptag() ==# "quote"
   end


### PR DESCRIPTION
Instead of generating links to `vimdoc.sourceforge.net`, the plugin now generates links to `vimhelp.appspot.com`
